### PR TITLE
feat: Add range_max_source config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ yarn build
 
 Check package.json for additional commands.
 
+### Configuration options
+
+#### Range Max Source
+
+Controls where the gauge's right-arm value (range max) comes from.
+
+- **Manual / Auto** (default) — uses the `Range Max Override` field if set, otherwise auto-computes from the value and target.
+- **First Measure (Row 2)** — when the query returns at least two rows of one measure, row 2 becomes the gauge's goal. Falls back to manual/auto if only one row is returned or the visualization is trellising by row.
+- **Second Measure** — when the query has a second measure, its value becomes the gauge's goal. Falls back to manual/auto if a second measure is not provided.
+
+This option is independent of `Target Source` — both can be set freely. For example, drive the goal from the second measure and keep the target marker pointing at an override value.
+
 #### Commit title format
 Commit titles on `master` branch follow [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) message spec. Your commit title must prefix one of 3 types and an optional `!` with the format `TYPE: commit title goes here`.
 * `fix` - a commit of the type fix patches a bug (correlates with PATCH in Semantic Versioning). `fix: Correct number formatting`

--- a/src/range.js
+++ b/src/range.js
@@ -1,0 +1,29 @@
+export function resolveGoal(config, data, meas, mesID) {
+  if (config.range_max_source === 'second' && meas.length >= 2) {
+    return data[0][meas[1].name].value;
+  }
+  if (
+    config.range_max_source === 'first' &&
+    config.viz_trellis_by !== 'row' &&
+    data.length >= 2
+  ) {
+    return data[1][mesID].value;
+  }
+  return null;
+}
+
+export function resolveRangeMax(chunk, config) {
+  if (chunk.goal != null && chunk.goal > 0) {
+    return chunk.goal;
+  }
+  if (config.range_max) {
+    return config.range_max;
+  }
+  const num = Math.max(
+    Math.ceil(chunk.value),
+    chunk.target ? Math.ceil(chunk.target) : 0
+  );
+  const len = (num + '').length;
+  const fac = Math.pow(10, len - 1);
+  return Math.ceil(num / fac) * fac;
+}

--- a/src/range.js
+++ b/src/range.js
@@ -20,8 +20,8 @@ export function resolveRangeMax(chunk, config) {
     return config.range_max;
   }
   const num = Math.max(
-    Math.ceil(chunk.value),
-    chunk.target ? Math.ceil(chunk.target) : 0
+    Math.ceil(chunk.value || 0),
+    Math.ceil(chunk.target || 0)
   );
   const len = (num + '').length;
   const fac = Math.pow(10, len - 1);

--- a/src/range.js
+++ b/src/range.js
@@ -16,7 +16,7 @@ export function resolveRangeMax(chunk, config) {
   if (chunk.goal != null && chunk.goal > 0) {
     return chunk.goal;
   }
-  if (config.range_max) {
+  if (config.range_max != null) {
     return config.range_max;
   }
   const num = Math.max(

--- a/src/range.test.js
+++ b/src/range.test.js
@@ -1,0 +1,81 @@
+import {resolveGoal, resolveRangeMax} from './range';
+
+const meas1 = [{name: 'm1'}];
+const meas2 = [{name: 'm1'}, {name: 'm2'}];
+
+describe('resolveGoal', () => {
+  test('returns null when source is manual', () => {
+    expect(resolveGoal({range_max_source: 'manual'}, [{m1: {value: 5}}], meas1, 'm1')).toBeNull();
+  });
+
+  test('returns null when source is undefined', () => {
+    expect(resolveGoal({}, [{m1: {value: 5}}], meas1, 'm1')).toBeNull();
+  });
+
+  test('returns second measure value when source is "second" and 2 measures present', () => {
+    const data = [{m1: {value: 5}, m2: {value: 80}}];
+    expect(resolveGoal({range_max_source: 'second'}, data, meas2, 'm1')).toBe(80);
+  });
+
+  test('returns null when source is "second" but only 1 measure present', () => {
+    expect(resolveGoal({range_max_source: 'second'}, [{m1: {value: 5}}], meas1, 'm1')).toBeNull();
+  });
+
+  test('returns row 2 of first measure when source is "first" and 2 rows present', () => {
+    const data = [{m1: {value: 5}}, {m1: {value: 90}}];
+    expect(resolveGoal({range_max_source: 'first'}, data, meas1, 'm1')).toBe(90);
+  });
+
+  test('returns null when source is "first" but only 1 row present', () => {
+    expect(resolveGoal({range_max_source: 'first'}, [{m1: {value: 5}}], meas1, 'm1')).toBeNull();
+  });
+
+  test('returns null when source is "first" and trellis is row', () => {
+    const data = [{m1: {value: 5}}, {m1: {value: 90}}];
+    const config = {range_max_source: 'first', viz_trellis_by: 'row'};
+    expect(resolveGoal(config, data, meas1, 'm1')).toBeNull();
+  });
+});
+
+describe('resolveRangeMax', () => {
+  test('returns goal when chunk.goal is positive', () => {
+    const chunk = {goal: 80, value: 50, target: null};
+    expect(resolveRangeMax(chunk, {range_max: null})).toBe(80);
+  });
+
+  test('goal wins over manual range_max', () => {
+    const chunk = {goal: 120, value: 50, target: null};
+    expect(resolveRangeMax(chunk, {range_max: 50})).toBe(120);
+  });
+
+  test('falls through to manual range_max when goal is null', () => {
+    const chunk = {goal: null, value: 50, target: null};
+    expect(resolveRangeMax(chunk, {range_max: 200})).toBe(200);
+  });
+
+  test('falls through to manual range_max when goal is zero', () => {
+    const chunk = {goal: 0, value: 50, target: null};
+    expect(resolveRangeMax(chunk, {range_max: 200})).toBe(200);
+  });
+
+  test('falls through to manual range_max when goal is negative', () => {
+    const chunk = {goal: -10, value: 50, target: null};
+    expect(resolveRangeMax(chunk, {range_max: 200})).toBe(200);
+  });
+
+  test('auto-computes from value when no goal and no range_max', () => {
+    const chunk = {goal: null, value: 37, target: null};
+    expect(resolveRangeMax(chunk, {range_max: null})).toBe(40);
+  });
+
+  test('auto-computes from max(value, target) when both present', () => {
+    const chunk = {goal: null, value: 37, target: 85};
+    expect(resolveRangeMax(chunk, {range_max: null})).toBe(90);
+  });
+
+  test('auto-compute rounds up to next decade', () => {
+    expect(resolveRangeMax({goal: null, value: 123, target: null}, {range_max: null})).toBe(200);
+    expect(resolveRangeMax({goal: null, value: 7, target: null}, {range_max: null})).toBe(7);
+    expect(resolveRangeMax({goal: null, value: 1234, target: null}, {range_max: null})).toBe(2000);
+  });
+});

--- a/src/viz_gauge.js
+++ b/src/viz_gauge.js
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import SSF from 'ssf';
 import {trimSpecialCharacters} from './string';
+import {resolveGoal, resolveRangeMax} from './range';
 
 const DEFAULT_MAX_RANGE = null;
 
@@ -147,6 +148,7 @@ function processPivot(data, queryResponse, config, viz, pivotKey) {
         ? tarLabel
         : config.target_label_override,
     target_dimension: tarDim,
+    goal: resolveGoal(config, data, meas, mesID),
   };
   return chunk;
 }
@@ -308,6 +310,7 @@ function processData(data, queryResponse, config, viz) {
         ? tarLabel
         : config.target_label_override,
     target_dimension: tarDim,
+    goal: resolveGoal(config, data, meas, mesID),
   };
   return chunk;
 }
@@ -406,6 +409,19 @@ looker.plugins.visualizations.add({
       order: 30,
       default: 0,
       display_size: 'half',
+    },
+    range_max_source: {
+      type: 'string',
+      label: 'Range Max Source',
+      display: 'select',
+      section: 'Plot',
+      values: [
+        {'Manual / Auto': 'manual'},
+        {'First Measure (Row 2)': 'first'},
+        {'Second Measure': 'second'},
+      ],
+      default: 'manual',
+      order: 29,
     },
     range_max: {
       type: 'number',
@@ -765,18 +781,9 @@ looker.plugins.visualizations.add({
       chunk = processData(data, queryResponse, config, this);
     }
 
-    if (!config.range_max || config.range_max === DEFAULT_MAX_RANGE) {
-      let num = Math.max(
-        Math.ceil(chunk.value),
-        chunk.target ? Math.ceil(chunk.target) : 0
-      );
-      var len = (num + '').length;
-      var fac = Math.pow(10, len - 1);
-      let default_max = Math.ceil(num / fac) * fac;
-      config.range_max = default_max;
-    }
     var viz = this;
     if (config.viz_trellis_by === 'none') {
+      const effective_range_max = resolveRangeMax(chunk, config);
       viz.radialProps = {
         cleanup: `gauge`,
         trellis_by: config.viz_trellis_by,
@@ -789,13 +796,13 @@ looker.plugins.visualizations.add({
         cutout: config.cutout,
         color: config.fill_color,
         gauge_background: config.background_color,
-        range: [config.range_min, config.range_max],
-        value: chunk.value > config.range_max ? config.range_max : chunk.value,
+        range: [config.range_min, effective_range_max],
+        value: chunk.value > effective_range_max ? effective_range_max : chunk.value,
         // value: config.dev_value,
         // value_rendered: config.dev_value.toString(),
         value_rendered: chunk.value_rendered,
         target:
-          chunk.target > config.range_max ? config.range_max : chunk.target,
+          chunk.target > effective_range_max ? effective_range_max : chunk.target,
         value_label: chunk.value_label,
         target_label: chunk.target_label,
         value_dimension: chunk.value_dimension,
@@ -846,6 +853,7 @@ looker.plugins.visualizations.add({
                 config.trellis_cols * config.trellis_rows,
                 queryResponse.pivots.length
               );
+        const effective_range_max = resolveRangeMax(d, config);
         viz.radialProps = {
           cleanup: `subgauge${i}`,
           trellis_by: config.viz_trellis_by,
@@ -859,10 +867,10 @@ looker.plugins.visualizations.add({
           cutout: config.cutout,
           color: config.fill_color,
           gauge_background: config.background_color,
-          range: [config.range_min, config.range_max],
-          value: d.value > config.range_max ? config.range_max : d.value,
+          range: [config.range_min, effective_range_max],
+          value: d.value > effective_range_max ? effective_range_max : d.value,
           value_rendered: d.value_rendered,
-          target: d.target > config.range_max ? config.range_max : d.target,
+          target: d.target > effective_range_max ? effective_range_max : d.target,
           value_label: d.value_label,
           target_label: d.target_label,
           value_dimension: d.value_dimension,


### PR DESCRIPTION
## Summary

Adds a new **Range Max Source** config option that controls where the gauge's right-arm value (range max / goal) comes from. Lets the goal be driven by data instead of only by the existing manual override.

Three modes:
- **Manual / Auto** (default) — existing behaviour: uses `Range Max Override` if set, otherwise auto-computes from value and target.
- **First Measure (Row 2)** — pulls the goal from row 2 of a single-measure query. Falls back to manual/auto if only one row is returned or the visualization is trellising by row.
- **Second Measure** — pulls the goal from a second measure column. Falls back to manual/auto if a second measure is not provided.

Independent of `Target Source`, so both can be set freely (for example, drive the goal from the second measure while keeping the target marker pointing at an override value).

## Implementation

- New helpers in `src/range.js` (`resolveGoal`, `resolveRangeMax`) with unit tests covering single/trellis/pivot data shapes and fallback paths.
- `viz_gauge.js` wires `resolveRangeMax` into both non-trellis and trellis render branches and resolves the goal per chunk in `processData` and `processPivot`.
- README documents the new option.

## Test plan

- [ ] `yarn test` passes (covers `src/range.test.js`)
- [ ] `yarn build` produces a working `bundle.js`
- [ ] Verified in Looker dev viz: single measure with 2 rows pulls goal from row 2
- [ ] Verified in Looker dev viz: two measures pulls goal from second measure
- [ ] Verified fallback to manual/auto when data shape doesn't match selected source
- [ ] Verified Target Source can be set independently of Range Max Source