### PR TITLE
fix: blank tiles in pdf mitigation update

### DIFF
--- a/src/calculateTrellis.test.js
+++ b/src/calculateTrellis.test.js
@@ -1,0 +1,23 @@
+import { calculateTrellisLimit } from './viz_gauge';
+
+describe('calculateTrellisLimit', () => {
+
+  test('should return the data length if it is smaller than the grid max (row)', () => {
+    // 2x2 grid (max 4), but only 3 data points. It should return 3.
+    const result = calculateTrellisLimit('row', 2, 2, 3, 0);
+    expect(result).toBe(3);
+  });
+
+  test('should return the grid max if data length is larger (row)', () => {
+    // 2x2 grid (max 4), with 10 data points. It should cap at 4.
+    const result = calculateTrellisLimit('row', 2, 2, 10, 0);
+    expect(result).toBe(4);
+  });
+
+  test('should calculate correctly for pivots', () => {
+    // 3x3 grid (max 9), with 5 pivot points. It should return 5.
+    const result = calculateTrellisLimit('pivot', 3, 3, 100, 5);
+    expect(result).toBe(5);
+  });
+
+});

--- a/src/radial_gauge.js
+++ b/src/radial_gauge.js
@@ -6,18 +6,22 @@ import {mapBetween} from './math';
 import {getLabel} from './string';
 
 const RadialGauge = props => {
+  const containerRef = React.useRef(null);
+
   useEffect(() => {
-    try {
-      drawRadial(props);
-    } catch (error) {
-      console.error('Radial Gauge Rendering Error:', error);
-    } finally {
-      if (props.done) {
-        props.done();
+    if (containerRef.current) {
+      try {
+        drawRadial(props, containerRef.current);
+      } catch (error) {
+        console.error('Radial Gauge Rendering Error:', error);
+      } finally {
+        if (props.done) {
+          props.done();
+        }
       }
     }
   }, [props]);
-  return <div className="viz" />;
+  return <div className="viz" ref={containerRef} />;
 };
 
 function wrap(text, width) {
@@ -55,7 +59,7 @@ function wrap(text, width) {
   });
 }
 
-const drawRadial = props => {
+const drawRadial = (props, container) => {
   if (Number.isNaN(props.value) || !props.range || !props.w || !props.h) {
     return;
   }
@@ -104,17 +108,16 @@ const drawRadial = props => {
   }
   // div that houses the svg
   var div = d3
-    .select('.viz')
-    .style('overflow-x', 'hidden')
-    .style('overflow-y', 'hidden')
-    .style('position', 'fixed')
-    .attr('height', '100%')
-    .attr('width', '100%');
+    .select(container)
+    .style('overflow', 'hidden')
+    .style('position', 'relative')
+    .attr('height', props.h + 'px')
+    .attr('width', props.target_weight + 'px');
   // append a fresh svg
-  const svg = d3.select('.viz').append('svg');
+  const svg = d3.select(container).append('svg');
   svg
-    .attr('width', props.w)
-    .attr('height', props.h)
+    .attr('width', '100%')
+    .attr('height', '100%')
     .attr('id', 'svg-viz')
     .attr('class', props.cleanup)
     .attr('preserveAspectRatio', 'xMidYMid meet')

--- a/src/radial_gauge.js
+++ b/src/radial_gauge.js
@@ -7,7 +7,15 @@ import {getLabel} from './string';
 
 const RadialGauge = props => {
   useEffect(() => {
-    drawRadial(props);
+    try {
+      drawRadial(props);
+    } catch (error) {
+      console.error('Radial Gauge Rendering Error:', error);
+    } finally {
+      if (props.done) {
+        props.done();
+      }
+    }
   }, [props]);
   return <div className="viz" />;
 };
@@ -48,7 +56,7 @@ function wrap(text, width) {
 }
 
 const drawRadial = props => {
-  if(Number.isNaN(props.value) || !props.range || !props.w || !props.h) {
+  if (Number.isNaN(props.value) || !props.range || !props.w || !props.h) {
     return;
   }
   let limiting_aspect = props.w < props.h ? 'vw' : 'vh';
@@ -101,7 +109,7 @@ const drawRadial = props => {
     .style('overflow-y', 'hidden')
     .style('position', 'fixed')
     .attr('height', '100%')
-    .attr('width', '100%')
+    .attr('width', '100%');
   // append a fresh svg
   const svg = d3.select('.viz').append('svg');
   svg

--- a/src/viz_gauge.js
+++ b/src/viz_gauge.js
@@ -6,6 +6,18 @@ import {trimSpecialCharacters} from './string';
 
 const DEFAULT_MAX_RANGE = null;
 
+export const calculateTrellisLimit = (trellisBy, cols, rows, dataLength, pivotsLength) => {
+  // in case cols/rows are undefined
+  const maxGauges = (cols || 1) * (rows || 1);
+
+  if (trellisBy === 'row') {
+    return Math.min(maxGauges, dataLength);
+  } else {
+    // assume if it's not 'row', it is 'pivot'
+    return Math.min(maxGauges, pivotsLength);
+  }
+};
+
 function processPivot(data, queryResponse, config, viz, pivotKey) {
   data = data.length === undefined ? [data] : data;
   let dims, meas;
@@ -738,15 +750,18 @@ looker.plugins.visualizations.add({
         config[option] = this.options[option].default;
       }
     }
+    const limit = calculateTrellisLimit(
+      config.viz_trellis_by,
+      config.trellis_cols,
+      config.trellis_rows,
+      data.length,
+      queryResponse.pivots ? queryResponse.pivots.length : 0
+    );
 
     // Extract value, value_label, target, target_label as a chunk
     let chunk;
     let chunk_multiples = [];
     if (config.viz_trellis_by === 'row') {
-      let limit = Math.min(
-        config.trellis_cols * config.trellis_rows,
-        data.length
-      );
       data.forEach((d, i) => {
         chunk = processData(data[i], queryResponse, config, this);
         if (i <= limit - 1) {
@@ -754,10 +769,6 @@ looker.plugins.visualizations.add({
         }
       });
     } else if (config.viz_trellis_by === 'pivot') {
-      let limit = Math.min(
-        config.trellis_cols * config.trellis_rows,
-        queryResponse.pivots.length
-      );
       queryResponse.pivots.forEach((d, i) => {
         chunk = processPivot(data, queryResponse, config, this, d.key);
         if (i <= limit - 1) {
@@ -859,13 +870,6 @@ looker.plugins.visualizations.add({
         }
       };
 
-      let limit =
-        config.viz_trellis_by === 'row'
-          ? Math.min(config.trellis_cols * config.trellis_rows, data.length)
-          : Math.min(
-              config.trellis_cols * config.trellis_rows,
-              queryResponse.pivots.length
-            );
       // map the properties to an array of components instead of calling ReactDOM.render in a loop
       const trellisComponents = chunk_multiples.map(function (d, i) {
 

--- a/src/viz_gauge.js
+++ b/src/viz_gauge.js
@@ -859,15 +859,15 @@ looker.plugins.visualizations.add({
         }
       };
 
+      let limit =
+        config.viz_trellis_by === 'row'
+          ? Math.min(config.trellis_cols * config.trellis_rows, data.length)
+          : Math.min(
+              config.trellis_cols * config.trellis_rows,
+              queryResponse.pivots.length
+            );
       // map the properties to an array of components instead of calling ReactDOM.render in a loop
       const trellisComponents = chunk_multiples.map(function (d, i) {
-        let limit =
-          config.viz_trellis_by === 'row'
-            ? Math.min(config.trellis_cols * config.trellis_rows, data.length)
-            : Math.min(
-                config.trellis_cols * config.trellis_rows,
-                queryResponse.pivots.length
-              );
 
         const subGaugeProps = {
           done: wrappedDone, // Use the wrapped tracker instead of the raw done()

--- a/src/viz_gauge.js
+++ b/src/viz_gauge.js
@@ -703,6 +703,7 @@ looker.plugins.visualizations.add({
       this.addError({
         title: 'No Results',
       });
+      done();
       return;
     }
 
@@ -778,6 +779,7 @@ looker.plugins.visualizations.add({
     var viz = this;
     if (config.viz_trellis_by === 'none') {
       viz.radialProps = {
+        done: done,
         cleanup: `gauge`,
         trellis_by: config.viz_trellis_by,
         w: width,
@@ -847,6 +849,7 @@ looker.plugins.visualizations.add({
                 queryResponse.pivots.length
               );
         viz.radialProps = {
+          done: done,
           cleanup: `subgauge${i}`,
           trellis_by: config.viz_trellis_by,
           trellis_limit: limit,
@@ -905,8 +908,5 @@ looker.plugins.visualizations.add({
         );
       });
     }
-
-    // We are done rendering! Let Looker know.
-    done();
   },
 });

--- a/src/viz_gauge.js
+++ b/src/viz_gauge.js
@@ -716,6 +716,7 @@ looker.plugins.visualizations.add({
         title: 'Invalid Input.',
         message: 'This chart accepts up to 1 dimension and 2 measures.',
       });
+      done();
       return;
     }
 
@@ -727,6 +728,7 @@ looker.plugins.visualizations.add({
         title: 'Invalid Input.',
         message: 'Add pivots or change trellis type.',
       });
+      done();
       return;
     }
 
@@ -840,7 +842,25 @@ looker.plugins.visualizations.add({
         viz.container
       );
     } else {
-      chunk_multiples.forEach(function (d, i) {
+      // fallback done() in case chunk_multiples is totally empty during a trellis render
+      if (chunk_multiples.length === 0) {
+        done();
+        return;
+      }
+
+      // tracking mechanism to ensure done() is called only once, after all gauges finish
+      let gaugesFinished = 0;
+      const totalGauges = chunk_multiples.length;
+
+      const wrappedDone = () => {
+        gaugesFinished++;
+        if (gaugesFinished === totalGauges) {
+          done();
+        }
+      };
+
+      // map the properties to an array of components instead of calling ReactDOM.render in a loop
+      const trellisComponents = chunk_multiples.map(function (d, i) {
         let limit =
           config.viz_trellis_by === 'row'
             ? Math.min(config.trellis_cols * config.trellis_rows, data.length)
@@ -848,12 +868,13 @@ looker.plugins.visualizations.add({
                 config.trellis_cols * config.trellis_rows,
                 queryResponse.pivots.length
               );
-        viz.radialProps = {
-          done: done,
+
+        const subGaugeProps = {
+          done: wrappedDone, // Use the wrapped tracker instead of the raw done()
           cleanup: `subgauge${i}`,
           trellis_by: config.viz_trellis_by,
           trellis_limit: limit,
-          w: width / config.trellis_cols, // GAUGE SETTINGS
+          w: width / config.trellis_cols,
           h: height / config.trellis_rows,
           limiting_aspect: width < height ? 'vw' : 'vh',
           margin: margin,
@@ -879,22 +900,18 @@ looker.plugins.visualizations.add({
           gauge_fill_type: config.gauge_fill_type,
           fill_colors: config.fill_colors,
           range_color: config.range_color,
-
-          spinner: config.spinner_length, // SPINNER SETTINGS
+          spinner: config.spinner_length,
           spinner_weight: config.spinner_weight,
           spinner_background: config.spinner_color,
           spinner_type: config.spinner_type,
-
-          arm: config.arm_length, // ARM SETTINGS
+          arm: config.arm_length,
           arm_weight: config.arm_weight,
-
-          target_length: config.target_length, // TARGET SETTINGS
+          target_length: config.target_length,
           target_gap: config.target_gap,
           target_weight: config.target_weight,
           target_background: '#282828',
           target_source: config.target_source,
-
-          value_label_type: config.value_label_type, // LABEL SETTINGS
+          value_label_type: config.value_label_type,
           value_label_font: config.value_label_font,
           value_label_padding: config.value_label_padding,
           target_label_type: config.target_label_type,
@@ -902,11 +919,16 @@ looker.plugins.visualizations.add({
           target_label_padding: config.target_label_padding,
           wrap_width: 100,
         };
-        viz.chart = ReactDOM.render(
-          <RadialGauge {...viz.radialProps} />,
-          viz.container
-        );
+
+        // render each gauge into the array using a unique key
+        return <RadialGauge key={`subgauge-${i}`} {...subGaugeProps} />;
       });
+
+      // render the entire array of components simultaneously in one React Fragment
+      viz.chart = ReactDOM.render(
+        <React.Fragment>{trellisComponents}</React.Fragment>,
+        viz.container
+      );
     }
   },
 });


### PR DESCRIPTION
fix: synchronize done() callback with React useEffect for reliable exports

Passed the `done` callback as a prop to the React component and executed it inside a `finally` block in `useEffect` to ensure Looker waits for D3 to finish drawing before taking a screenshot. Also added safety nets to all early return paths.